### PR TITLE
add mill support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
 
 .bsp
 .idea
+.bloop
+.metals
+.vscode
 target
 .DS_Store

--- a/src/main/scala/update/DependencyUpdater.scala
+++ b/src/main/scala/update/DependencyUpdater.scala
@@ -28,9 +28,6 @@ case class DependencyUpdater(versions: Versions, files: Files) {
   def allUpdateOptions: IO[Throwable, Chunk[(DependencyWithLocation, UpdateOptions)]] = for {
     pwd <- System.property("user.dir").someOrFailException
 
-    isValidSbtProject <- zio.nio.file.Files.exists(Path(pwd) / "build.sbt")
-    _                 <- ZIO.fail(AppError.MissingBuildSbt).unless(isValidSbtProject)
-
     sourceFiles <- files.allBuildSources(pwd)
     deps         = DependencyParser.getDependencies(sourceFiles)
     updates     <- ZIO.foreachPar(deps)(getUpdateOptions)

--- a/src/main/scala/update/FileUtils.scala
+++ b/src/main/scala/update/FileUtils.scala
@@ -11,6 +11,15 @@ object FileUtils {
    * Returns a Stream of all Scala
    */
   def allScalaFiles(path: Path): ZStream[Any, IOException, Path] =
+    allFilesWithExt(path, ".scala")
+
+  /**
+   * Returns a Stream of all mill build file (ammonite script)
+   */
+  def allMillFiles(path: Path): ZStream[Any, IOException, Path] =
+    allFilesWithExt(path, ".sc")
+
+  private def allFilesWithExt(path: Path, extension: String): ZStream[Any, IOException, Path] =
     ZStream.whenZIO(Files.isDirectory(path)) {
       Files
         .newDirectoryStream(path)
@@ -21,7 +30,6 @@ object FileUtils {
                    else ZStream.succeed(path)
           } yield res
         }
-        .filter(_.toString.endsWith(".scala"))
+        .filter(_.toString.endsWith(extension))
     }
-
 }

--- a/src/main/scala/update/FilesLive.scala
+++ b/src/main/scala/update/FilesLive.scala
@@ -12,11 +12,12 @@ final case class FilesLive() extends Files {
     val rootPath          = Path(root)
     val projectScalaPaths = FileUtils.allScalaFiles(rootPath / "project")
     val buildSbtPath      = ZStream.succeed(rootPath / "build.sbt")
+    val buildMillPath     = FileUtils.allMillFiles(rootPath)
     val pluginsPath = ZStream
       .succeed(rootPath / "project" / "plugins.sbt")
-      .filterZIO(path => zio.nio.file.Files.exists(path))
 
-    val allSourcePaths = projectScalaPaths ++ buildSbtPath ++ pluginsPath
+    val allSourcePaths = (projectScalaPaths ++ buildSbtPath ++ pluginsPath ++ buildMillPath)
+      .filterZIO(path => zio.nio.file.Files.exists(path))
 
     allSourcePaths.mapZIO { path =>
       ZIO

--- a/src/test/scala/update/MillDependencyParserSpec.scala
+++ b/src/test/scala/update/MillDependencyParserSpec.scala
@@ -1,0 +1,97 @@
+package update
+
+import zio.Chunk
+import zio.nio.file.Path
+import zio.test._
+
+object MillDependencyParserSpec extends ZIOSpecDefault {
+
+  val spec =
+    suite("MillDependencyParserSpec")(
+      test("parse dependencies from trees") {
+        val sourceFiles =
+          Chunk(
+            SourceFile(
+              Path("fake"),
+              """
+import mill._, scalalib._
+
+object V {
+  val zio = "1.0.14"
+  val `zio-json` = "0.3.0"
+  val zioTest = "1.0.14"
+}
+
+object foo extends ScalaModule {
+  def scalaVersion = "2.13.8"
+  import V._
+  def ivyDeps = Agg(
+    ivy"dev.zio::zio:$zio",
+    ivy"dev.zio::zio-test::${V.zioTest}",
+    ivy"dev.zio::zio-json:${V.`zio-json`}",
+  )
+}
+
+"""
+            )
+          )
+
+        val deps = DependencyParser.getDependencies(sourceFiles)
+
+        val expected =
+          Chunk(
+            Dependency(Group("dev.zio"), Artifact("zio"), Version("1.0.14")),
+            Dependency(Group("dev.zio"), Artifact("zio-test"), Version("1.0.14")),
+            Dependency(Group("dev.zio"), Artifact("zio-json"), Version("0.3.0"))
+          )
+
+        assertTrue(deps.map(_.dependency) == expected)
+      },
+      test("parse dependencies from multiple files") {
+        val sourceFiles =
+          Chunk(
+            SourceFile(
+              Path("fake"),
+              """
+import mill._, scalalib._
+import $file.Versions, Versions.V, Versions.V._
+
+object foo extends ScalaModule {
+  def scalaVersion = "2.13.8"
+  def ivyDeps = Agg(
+    ivy"dev.zio::zio:$zio",
+    ivy"dev.zio::zio-test::${V.zioTest}",
+    ivy"dev.zio::zio-json:${V.`zio-json`}",
+  )
+}
+
+"""
+            ),
+            SourceFile(
+              Path("Versions.sc"),
+              """
+import mill._, scalalib._
+
+object V {
+  val zio = "1.0.14"
+  val `zio-json` = "0.3.0"
+  val zioTest = "1.0.14"
+}
+"""
+            )
+          )
+
+        val deps = DependencyParser.getDependencies(sourceFiles)
+
+        val expected =
+          Chunk(
+            Dependency(Group("dev.zio"), Artifact("zio"), Version("1.0.14")),
+            Dependency(Group("dev.zio"), Artifact("zio-test"), Version("1.0.14")),
+            Dependency(Group("dev.zio"), Artifact("zio-json"), Version("0.3.0"))
+          )
+
+        assertTrue(deps.map(_.dependency) == expected)
+      }
+    )
+
+}

--- a/src/test/scala/update/MillDependencyUpdaterSpec.scala
+++ b/src/test/scala/update/MillDependencyUpdaterSpec.scala
@@ -1,0 +1,93 @@
+package update
+
+import update.versions.Versions
+import zio.ZIO
+import zio.test._
+
+object MillDependencyUpdaterSpec extends ZIOSpecDefault {
+  def spec =
+    suite("MillDependencyUpdaterSpec")(
+      test("updateDependencies") {
+
+        val buildMillString =
+          """
+import $file.Dependencies, Dependencies.Dependencies
+
+object foo extends ScalaModule {
+  def scalaVersion = "2.13.8"
+  val zioVersion = "1.0.12"
+
+  def ivyDeps = Agg(
+    ivy"dev.zio::zio:$zioVersion",
+    ivy"dev.zio::zio-json:0.2.0",
+    ivy"io.getquill::quill-jdbc-zio:${Dependencies.quill}",
+    ivy"dev.cheleb:zio-pravega:0.1.0-RC12"
+  )
+}
+"""
+
+        val expectedMillString =
+          """
+import $file.Dependencies, Dependencies.Dependencies
+
+object foo extends ScalaModule {
+  def scalaVersion = "2.13.8"
+  val zioVersion = "2.0.1"
+
+  def ivyDeps = Agg(
+    ivy"dev.zio::zio:$zioVersion",
+    ivy"dev.zio::zio-json:0.2.0",
+    ivy"io.getquill::quill-jdbc-zio:${Dependencies.quill}",
+    ivy"dev.cheleb:zio-pravega:0.1.0-RC12"
+  )
+}
+"""
+
+        val dependenciesString =
+          """
+object Dependencies {
+  val quill = "0.9.0"
+}
+"""
+
+        val expectedDependenciesString =
+          """
+object Dependencies {
+  val quill = "0.9.5"
+}
+"""
+
+        ZIO.scoped {
+          for {
+            tempDir         <- zio.nio.file.Files.createTempDirectoryScoped(Some("dependency-updater-spec"), Iterable.empty)
+            buildMillPath    = tempDir / "build.sc"
+            dependenciesPath = tempDir / "Dependencies.sc"
+            _               <- zio.nio.file.Files.createFile(buildMillPath)
+            _               <- zio.nio.file.Files.createDirectory(tempDir / "project")
+            _               <- zio.nio.file.Files.createFile(dependenciesPath)
+            _               <- ZIO.writeFile(buildMillPath.toString, buildMillString)
+            _               <- ZIO.writeFile(dependenciesPath.toString, dependenciesString)
+            _               <- TestSystem.putProperty("user.dir", tempDir.toString)
+            _               <- ZIO.serviceWithZIO[DependencyUpdater](_.updateDependencies)
+            newBuildSbt     <- ZIO.readFile(buildMillPath.toString)
+            newDependencies <- ZIO.readFile(dependenciesPath.toString)
+          } yield assertTrue(
+            newBuildSbt == expectedMillString,
+            newDependencies == expectedDependenciesString
+          )
+
+        }
+      }
+    ).provide(
+      DependencyUpdater.live,
+      Files.live,
+      Versions.test(
+        Map(
+          (Group("dev.zio"), Artifact("zio"))                -> List(Version("2.0.0")),
+          (Group("io.getquill"), Artifact("quill-jdbc-zio")) -> List(Version("0.9.5")),
+          (Group("dev.zio"), Artifact("zio-json"))           -> List(Version("0.3.1")),
+          (Group("dev.cheleb"), Artifact("zio-pravega"))     -> List(Version("0.1.0-RC9"))
+        )
+      )
+    )
+}


### PR DESCRIPTION
This PR is related to https://github.com/kitlangton/scala-update/issues/15
It add basic support for mill.

It was actually easier to add this support than I originally thought, it works by parsing all the `*.sc` files at the root of the project (we could dynamically load the file based on the `import $file.XXX` of `build.sc` in the future).

Because in mill dependencies are expressed as string, we need a bit of parsing inside the `Lit.String` to support all Scala runtime (`::` and `:`).

I had to remove a check that assumes that `build.sbt` is present but I left the `MissingBuildSbt` error for now as we might need it later (or maybe refactor it to `MissingBuildTool`). I think that the error handling could be done in the `allBuildSources` method that could check if there is zero or more than one build tool found on the current project.

One of the issue with the current implementation would be on a project that has both a `build.sc` and `build.sbt`.
I've run the mill updater on bot4s/telegram and the output was 

```
 SCALA INTERACTIVE UPDATE                                                          
 ────────────────────────                                                          
  ▣ cats-effect   3.3.12 → 3.3.13 3.4-389-3862cf0                                  
  ▣ cats-effect   2.5.5  → 3.3.13 3.4-389-3862cf0                                  
  ▣ circe-core    0.14.2 → 0.15.0-M1                                               
    circe-generic                                                                  
    circe-parser                                                                   
    circe-literal                                                                  
 ❯▣ scalatest     3.2.12 → 3.3.0-SNAP3                                             
                                                                                   
 space toggle  a toggle all  ↑/↓ move up/down  enter update  g show groups  q quit 
                                                                                   
                                    
 UPDATED DEPENDENCIES               
 ────────────────────               
 cats-effect   3.3.12 → 3.3.13      
 cats-effect   2.5.5  → 3.3.13      
 circe-core    0.14.2 → 0.15.0-M1   
 circe-generic 0.14.2 → 0.15.0-M1   
 circe-parser  0.14.2 → 0.15.0-M1   
 circe-literal 0.14.2 → 0.15.0-M1   
 scalatest     3.2.12 → 3.3.0-SNAP3 
```                                    

```diff
diff --git a/build.sc b/build.sc
index dde790c..7e949bb 100644
--- a/build.sc
+++ b/build.sc
@@ -7,12 +7,12 @@ val ScalaVersions = Seq("2.12.16", "2.13.8")
 object library {
 
   object Version {
-    val circe              = "0.14.2"
+    val circe              = "0.15.0-M1"
     val cats               = "2.8.0"
-    val catsEffect         = "2.5.5"
-    val catsEffect3        = "3.3.12"
+    val catsEffect         = "3.3.13"
+    val catsEffect3        = "3.3.13"
     val sttp               = "3.6.2"
-    val scalaTest          = "3.2.12"
+    val scalaTest          = "3.3.0-SNAP3"
     val scalaMockScalaTest = "5.2.0"
     val scalaLogging       = "3.9.5"
     val logback            = "1.2.11"
```
