### PR TITLE
Use Coursier's resolution mechanism for mirrors and repositories

### DIFF
--- a/src/main/scala/update/versions/VersionsLive.scala
+++ b/src/main/scala/update/versions/VersionsLive.scala
@@ -1,20 +1,21 @@
 package update.versions
 
 import coursier.cache.FileCache
-import coursier.{Module, ModuleName, Organization, Repositories}
+import coursier.{Module, ModuleName, Organization, Resolve}
 import update.versions.ZioSyncInstance._
 import update.{Artifact, Group, Version}
 import zio._
 
 final case class VersionsLive() extends Versions {
-  private val cache = FileCache[Task]()
+  private val cache   = FileCache[Task]()
+  private val resolve = Resolve[Task](cache)
 
-  // Currently hardcoded to Maven Central and scala 2.13
+  // Currently hardcoded to Scala 2.13
   override def getVersions(group: Group, artifact: Artifact): Task[List[Version]] =
-    // Gets library versions from Maven Central
+    // Gets library versions
     getVersions(group, artifact, "2.13", None)
       .filterOrElse(_.nonEmpty) {
-        // Gets plugin versions from Maven Central
+        // Gets plugin versions
         getVersions(group, artifact, "2.12", Some("1.0"))
       }
 
@@ -24,25 +25,30 @@ final case class VersionsLive() extends Versions {
     scalaVersion: String,
     sbtVersion: Option[String]
   ): Task[List[Version]] =
-    Repositories.central
-      .versions(
-        Module(
-          Organization(group.value),
-          ModuleName(artifact.value),
-          Map("scalaVersion" -> scalaVersion) ++ sbtVersion.map("sbtVersion" -> _)
-        ),
-        cache.fetch,
-        versionsCheckHasModule = true
-      )
-      .run
-      .map(_.left.map(new Error(_)))
-      .absolve
-      .map { case (versions, _) =>
-        versions.available.map(Version(_))
-      }
-      .catchSome {
-        case e if e.getMessage.contains("not found") =>
-          ZIO.succeed(List.empty)
-      }
-
+    resolve.finalRepositories.flatMap { repositories =>
+      ZIO
+        .foreachPar(repositories) { repository =>
+          repository
+            .versions(
+              Module(
+                Organization(group.value),
+                ModuleName(artifact.value),
+                Map("scalaVersion" -> scalaVersion) ++ sbtVersion.map("sbtVersion" -> _)
+              ),
+              cache.fetch,
+              versionsCheckHasModule = true
+            )
+            .run
+            .map(_.left.map(new Error(_)))
+            .absolve
+            .map { case (versions, _) =>
+              versions.available.map(Version(_))
+            }
+            .catchSome {
+              case e if e.getMessage.contains("not found") =>
+                ZIO.succeed(List.empty)
+            }
+        }
+        .map(_.flatten.toList)
+    }
 }


### PR DESCRIPTION
Hi.

Defaulting to Maven Central doesn't work for people behind internal mirrors.
This PR simply uses Coursier's `Resolve#finalRepositories` mechanism instead.

I'm not super familiar with Zio, maybe there's a better way than `flatMap ... foreachPar ... map(_.flatten)` 🙂 